### PR TITLE
Craft armure noc lvl 30 + effets permanents

### DIFF
--- a/armures/nocturite-boots.md
+++ b/armures/nocturite-boots.md
@@ -20,7 +20,7 @@ Les bottes en Nocturite font partie de la meilleure armure disponible sur Hister
  -== https://raw.githubusercontent.com/HisteriaMC/histeria-wiki/main/.assets/armors/nocturite-boots.png
 -=-
 
-Pour pouvoir les fabriquer, vous devez être niveau 50 dans le métier de Bûcheron.
+Pour pouvoir les fabriquer, vous devez être niveau 30 dans le métier de Bûcheron.
 
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |

--- a/armures/nocturite-boots.md
+++ b/armures/nocturite-boots.md
@@ -25,4 +25,4 @@ Pour pouvoir les fabriquer, vous devez être niveau 30 dans le métier de Bûche
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |
 | ----------------- | --------------- | ---------- |
-| Vitesse III | 1,5 | 20000 |
+| Sauts améliorés II| 1,5 | 20000 |

--- a/armures/nocturite-chestplate.md
+++ b/armures/nocturite-chestplate.md
@@ -20,7 +20,7 @@ Le plastron en Nocturite fait partie de la meilleure armure disponible sur Histe
  -== https://raw.githubusercontent.com/HisteriaMC/histeria-wiki/main/.assets/armors/nocturite-chestplate.png
 -=-
 
-Pour pouvoir le fabriquer, vous devez être niveau 50 dans le métier mineur.
+Pour pouvoir le fabriquer, vous devez être niveau 30 dans le métier mineur.
 
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |

--- a/armures/nocturite-helmet.md
+++ b/armures/nocturite-helmet.md
@@ -20,7 +20,7 @@ Le casque en Nocturite fait partie de la meilleure armure disponible sur Histeri
  -== https://raw.githubusercontent.com/HisteriaMC/histeria-wiki/main/.assets/armors/nocturite-helmet.png
 -=-
 
-Pour pouvoir le favriquer, vous devez être niveau 50 dans le métier d'agriculteur.
+Pour pouvoir le favriquer, vous devez être niveau 30 dans le métier d'agriculteur.
 
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |

--- a/armures/nocturite-leggings.md
+++ b/armures/nocturite-leggings.md
@@ -20,7 +20,7 @@ Les jambières en Nocturite font partie de la meilleure armure disponible sur Hi
  -== https://raw.githubusercontent.com/HisteriaMC/histeria-wiki/main/.assets/armors/nocturite-leggings.png
 -=-
 
-Pour pouvoir les fabriquer, vous devez être niveau 50 dans le métier de mineur.
+Pour pouvoir les fabriquer, vous devez être niveau 5m30 dans le métier de mineur.
 
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |

--- a/armures/nocturite-leggings.md
+++ b/armures/nocturite-leggings.md
@@ -25,4 +25,4 @@ Pour pouvoir les fabriquer, vous devez être niveau 30 dans le métier de mineur
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |
 | ----------------- |-----------------| ---------- |
-| Vitesse II & Hâte II | 3 | 20000 |
+| Vitesse II | 3 | 20000 |

--- a/armures/nocturite-leggings.md
+++ b/armures/nocturite-leggings.md
@@ -20,7 +20,7 @@ Les jambières en Nocturite font partie de la meilleure armure disponible sur Hi
  -== https://raw.githubusercontent.com/HisteriaMC/histeria-wiki/main/.assets/armors/nocturite-leggings.png
 -=-
 
-Pour pouvoir les fabriquer, vous devez être niveau 5m30 dans le métier de mineur.
+Pour pouvoir les fabriquer, vous devez être niveau 30 dans le métier de mineur.
 
 ### Informations
 | Effets de potions | Points d'armure | Durabilité |


### PR DESCRIPTION
Le craft des pièces d'armure en nocturite est disponible au niveau 30 de chaque métier