### PR TITLE
Inversion utilités Éclair et Lyre

### DIFF
--- a/objets/magic-lyre.md
+++ b/objets/magic-lyre.md
@@ -8,4 +8,4 @@ La lyre magique est un objet obtenable en tuant Apollon en faisant faisant le pl
 Un son de lyre est joué lors de son utilisation ! Elle ne peut qu'être utilisé qu'une seule fois.
 
 ## Utilité
-Objet s'utilisant sur un joueur. Elle a pour effet de déplacer une pièce de son armure dans son inventaire, elle permet également d'immobiliser votre adversaire en l'air. Lorsqu'elle est utilisée, un éclair apparaît sur le joueur, mais ne lui inflige aucun dégât. 
+Elle permet d'augmenter de 225% les dégâts d'[enchantements moddés](https://histeria.fr/wiki/enchantements) reçus par l'adversaire pendant 10 secondes.

--- a/objets/zeus-flash.md
+++ b/objets/zeus-flash.md
@@ -8,4 +8,4 @@ Objet de boss qui a une chance de s'obtenir en tuant Zeus en faisant le plus de 
 Un éclair apparait sur le joueur, mais ne lui inflige aucun dégat. Il ne peut qu'être utilisé 1 fois.
 
 ## Utilité
-Elle permet d'augmenter de 225% les dégâts d'[enchantements moddés](https://histeria.fr/wiki/enchantements) reçus par l'adversaire pendant 10 secondes. 
+Objet s'utilisant sur un joueur. Il a pour effet de déplacer une pièce de son armure dans son inventaire, il permet également d'immobiliser votre adversaire en l'air. Lorsqu'il est utilisée, un éclair apparaît sur le joueur, mais ne lui inflige aucun dégât. 


### PR DESCRIPTION
Les utilités de la Lyre d'Apollo et de l'Éclair de Zeus était inversées.